### PR TITLE
Customizable icon prefix for branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@ let g:lightline = {
 
 Also useful is `gitbranch#icon_and_name`, which will return the branch name prepended with a customizable icon (`↳` by default). This function helps maximize compatibility with [lightline.vim](https://github.com/itchyny/lightline.vim) as `component_function` can be used (instead of `component`), which prevents separators from being drawn when the `component_function` is empty (*e.g.*, there is no git repository).
 
-You can set a custom icon to be used in conjuction with `gitbranch#icon_and_name`:
+You can set a custom icon to be used in conjuction with `gitbranch#icon_and_name`. For example:
 ```vim
 let g:gitbranch_icon = '↝'
+
+let g:lightline = {
+      \ 'active': {
+      \   'left': [ [ 'mode', 'paste' ],
+      \             [ 'gitbranch', 'readonly', 'filename', 'modified' ] ]
+      \ },
+      \ 'component_function': {
+      \   'gitbranch': 'gitbranch#icon_and_name'
+      \ },
+      \ }
 ```
 
 See the [README.md of lightline](https://github.com/itchyny/lightline.vim) for further details.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ let g:lightline = {
       \ },
       \ }
 ```
+
+Also useful is `gitbranch#icon_and_name`, which will return the branch name prepended with a customizable icon (`↳` by default). This function helps maximize compatibility with [lightline.vim](https://github.com/itchyny/lightline.vim) as `component_function` can be used (instead of `component`), which prevents separators from being drawn when the `component_function` is empty (*e.g.*, there is no git repository).
+
+You can set a custom icon to be used in conjuction with `gitbranch#icon_and_name`:
+```vim
+let g:gitbranch_icon = '↝'
+```
+
 See the [README.md of lightline](https://github.com/itchyny/lightline.vim) for further details.
 
 ## Installation

--- a/autoload/gitbranch.vim
+++ b/autoload/gitbranch.vim
@@ -7,6 +7,7 @@
 
 let s:save_cpo = &cpo
 set cpo&vim
+let g:gitbranch_icon = get(g:, 'gitbranch_icon', '↳')
 
 function! gitbranch#name() abort
   if get(b:, 'gitbranch_pwd', '') !=# expand('%:p:h') || !has_key(b:, 'gitbranch_path')
@@ -21,6 +22,11 @@ function! gitbranch#name() abort
     endif
   endif
   return ''
+endfunction
+
+function! gitbranch#icon_and_name() abort
+	let l:bname = gitbranch#name()
+	return l:bname != '' ? g:gitbranch_icon . ' ' . l:bname : ''
 endfunction
 
 function! gitbranch#dir(path) abort


### PR DESCRIPTION
Using component_function in lightline has the advantage that if the returned value is empty, lightline automatically excludes the field and separator. Using a component to implement a custom function that wraps gitbranch#name to add the icon as a prefix, but returns an empty string when there is no branch name, results in an extra separator in the statusline.

This patch adds gitbranch#icon_and_name with a customizable g:gitbranch_icon variable to return: "<icon> <branch_name>"