### PR TITLE
fix(worktree): didn't show git branch inside worktree directory

### DIFF
--- a/autoload/gitbranch.vim
+++ b/autoload/gitbranch.vim
@@ -35,7 +35,7 @@ function! gitbranch#dir(path) abort
     elseif type ==# 'file'
       let reldir = get(readfile(dir), 0, '')
       if reldir =~# '^gitdir: '
-        return simplify(path . '/' . reldir[8:])
+        return simplify(reldir[8:])
       endif
     elseif git_modules && isdirectory(path.'/objects') && isdirectory(path.'/refs') && getfsize(path.'/HEAD') > 10
       return path


### PR DESCRIPTION
I've noticed that `vim-gitbranch` plugin didn't show the git branch name inside of worktree directory. And I found out that the cause was  the path inside of `.git` file or to be precise the `gitdir` content inside of `.git` file already give the full path, so the return value when `.git` is a file is something like this:
```sh
/home/username/worktree-directory/home/username/git-repo/.git/worktrees/worktree-directory/HEAD
```
which doesn't exist.

I omitted the `path` so that this only return the content of `gitdir`. Please let me know if there's a case of `gitdir` doesn't have a full path to the `HEAD` file, I only test this with git worktree after all.

My git version by the time of this PR: 2.34.1